### PR TITLE
feat: support native or easyDialog and change cart to single-slot stacking; add translated READMEs and example

### DIFF
--- a/MenuStore.inc
+++ b/MenuStore.inc
@@ -1,8 +1,13 @@
 /*
-	MenuStore - Version 4.2
+	MenuStore - Version 4.3
 	Created by CaioTJF
 */
 
+// easyDialog detection - checks if easyDialog is available
+// The detection is done via the Dialog macro which is defined by easyDialog
+#if defined Dialog
+	#define MS_USE_EASYDIALOG
+#endif
 
 /*	
 	You can NOT change 
@@ -422,7 +427,11 @@ public OnPlayerClickPlayerTextDraw(playerid, PlayerText:playertextid)
 						MenuStore_ToggleControll(playerid, false);
 						MenuStore_SelectRow(playerid, i);
 						format(ms_String, sizeof(ms_String), ""#MS_COLOR_TEXT_DIALOG""#MS_MSG_DIALOG" ("#MS_WORD_LIMIT": %d)", ms_Items[playerid][index][ms_ItemStack]);
-						ShowPlayerDialog(playerid, DIALOG_MSTORE, DIALOG_STYLE_INPUT, ""#MS_COLOR_TITLE_DIALOG""#MS_MSG_TITLE_DIALOG":", ms_String, MS_WORD_GO, MS_WORD_CANCEL);
+						#if defined MS_USE_EASYDIALOG
+							Dialog_Show(playerid, MS_DialogQuantity, DIALOG_STYLE_INPUT, ""#MS_COLOR_TITLE_DIALOG""#MS_MSG_TITLE_DIALOG":", ms_String, MS_WORD_GO, MS_WORD_CANCEL);
+						#else
+							ShowPlayerDialog(playerid, DIALOG_MSTORE, DIALOG_STYLE_INPUT, ""#MS_COLOR_TITLE_DIALOG""#MS_MSG_TITLE_DIALOG":", ms_String, MS_WORD_GO, MS_WORD_CANCEL);
+						#endif
 					}
 					else
 					{
@@ -620,6 +629,32 @@ public OnPlayerConnect(playerid)
 
 //-------------------------------------------
 
+// easyDialog handler (when easyDialog is available)
+#if defined MS_USE_EASYDIALOG
+Dialog:MS_DialogQuantity(playerid, response, listitem, inputtext[])
+{
+	MenuStore_ToggleControll(playerid, true);
+	MenuStore_CloseDescription(playerid);
+
+	if(!response || ms_Info[playerid][ms_Selected] == -1 || isnull(inputtext))
+	{
+		MenuStore_UnselectRow(playerid);
+		return true;
+	}	
+
+	new index = ms_Info[playerid][ms_Selected]+(MS_MAX_ITEMS_PER_PAGE * (ms_Info[playerid][ms_CurrentPage] - 1));
+	MenuStore_UnselectRow(playerid);
+
+	if(strval(inputtext) < 1 || strval(inputtext) > ms_Items[playerid][index][ms_ItemStack])
+		return true;
+
+	MenuStore_AddToCart(playerid, ms_Items[playerid][index][ms_ItemID], ms_Items[playerid][index][ms_ItemPrice], strval(inputtext));
+	return true;
+}
+#endif
+
+// Native dialog handler (fallback when easyDialog is not available)
+#if !defined MS_USE_EASYDIALOG
 public OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
 {
 	if(dialogid == DIALOG_MSTORE)
@@ -659,6 +694,7 @@ public OnDialogResponse(playerid, dialogid, response, listitem, inputtext[])
 
 #if defined MS_OnDialogResponse
     forward MS_OnDialogResponse(playerid, dialogid, response, listitem, inputtext[]);
+#endif
 #endif
 
 //-------------------------------------------
@@ -831,6 +867,19 @@ stock MenuStore_GetCartTotalValue(playerid)
 
 stock MenuStore_AddToCart(playerid, itemid, price, amount)
 {
+	// First, check if item already exists in cart and stack it
+	for(new i = 0; i < MS_MAX_ITEMS_CART; i++)
+	{
+		if(ms_Cart[playerid][ms_Cart_ItemID][i] == itemid)
+		{
+			ms_Cart[playerid][ms_Cart_ItemAmount][i] += amount;
+			MenuStore_UpdateCart(playerid);
+			MenuStore_UpdateCartTotalValue(playerid);
+			return;
+		}
+	}
+	
+	// If item not found in cart, add to first empty slot
 	for(new i = 0; i < MS_MAX_ITEMS_CART; i++)
 	{
 		if(ms_Cart[playerid][ms_Cart_ItemID][i] == MSTORE_INVALID_ITEM_ID)

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,48 @@
+# MenuStore
+MenuStore es un include ligero para SA-MP que permite crear tiendas configurables dentro del juego usando Textdraws.
+
+Características
+- Crear tiendas multipágina con descripciones y vistas previas
+- Carrito incorporado con ranuras limitadas y visualización del valor total
+- Soporte opcional para easyDialog cuando está disponible
+- Cadenas localizables (por defecto en inglés; PT-BR y Español incluidos)
+
+Vista previa
+![MenuStore](https://i.imgur.com/gH1k6t4.jpg)
+
+Enlaces rápidos
+- README en inglés: [README.md](README.md)
+- Português (pt-BR): [README.pt-BR.md](README.pt-BR.md)
+- Español: [README.es.md](README.es.md)
+- Script de ejemplo: [examples/example.pwn](examples/example.pwn)
+
+Documentación
+https://sampforum.blast.hk/showthread.php?tid=644913
+
+Inicio rápido
+1. Coloca el include en la carpeta `includes` y añade `#include <MenuStore>` en tu script.
+2. Añade items con `MenuStore_AddItem(...)` antes de mostrar la tienda al jugador.
+3. Muestra la tienda usando `MenuStore_Show(playerid, StoreID, "Store Name");`
+
+Ejemplo (muy corto)
+1. Añade items:
+
+```pawn
+MenuStore_AddItem(playerid, 1, 342, "Granada", 500, "Lanzar para explotar.", 200);
+```
+
+2. Muestra la tienda:
+
+```pawn
+MenuStore_Show(playerid, Weapon_Shop, "Tienda de Armas");
+```
+
+3. Implementa el callback de la tienda (ver [examples/example.pwn](examples/example.pwn) para un ejemplo completo):
+
+```pawn
+Store:Weapon_Shop(playerid, response, itemid, modelid, price, amount, itemname[])
+```
+
+Notas
+- El include proporciona textos por defecto en Portugués y Español cuando `MENUSTORE_PTBR` o `MENUSTORE_SPANISH` se definen antes de incluir.
+- Mantén `MS_MAX_ITEMS` y otras macros configurables según lo necesites.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,48 @@
 # MenuStore
-This include allows you to create many types of stores using Textdraws.
+MenuStore is a lightweight SA-MP include that lets you create configurable in-game stores using Textdraws.
 
+Features
+- Create multi-page item stores with descriptions and previews
+- Built-in cart with limited slots and total value display
+- Optional easyDialog support if available
+- Localizable strings (English by default; PT-BR and Spanish provided)
+
+Preview
 ![MenuStore](https://i.imgur.com/gH1k6t4.jpg)
 
-Doc
+Quick links
+- English README: [README.md](README.md)
+- Português (pt-BR): [README.pt-BR.md](README.pt-BR.md)
+- Español: [README.es.md](README.es.md)
+-- Example store script: [examples/example.pwn](examples/example.pwn)
+
+Documentation
 https://sampforum.blast.hk/showthread.php?tid=644913
+
+Quick start
+1. Place the include in your `includes` folder and add `#include <MenuStore>` to your script.
+2. Add items with `MenuStore_AddItem(...)` before showing a store to a player.
+3. Show the store using `MenuStore_Show(playerid, StoreID, "Store Name");`
+
+Example (very short)
+1. Add items:
+
+```pawn
+MenuStore_AddItem(playerid, 1, 342, "Grenade", 500, "Throw to explode.", 200);
+```
+
+2. Show the store:
+
+```pawn
+MenuStore_Show(playerid, Weapon_Shop, "Weapon Shop");
+```
+
+3. Implement the store callback (see [examples/newStore_example.pwn](examples/example.pwn) for a full sample):
+
+```pawn
+Store:Weapon_Shop(playerid, response, itemid, modelid, price, amount, itemname[])
+```
+
+Notes
+- The include provides optional Portuguese and Spanish default text when `MENUSTORE_PTBR` or `MENUSTORE_SPANISH` are defined before including.
+- Keep `MS_MAX_ITEMS` and other macros configurable in your project if needed.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,48 @@
+# MenuStore
+MenuStore é um include leve para SA-MP que permite criar lojas configuráveis no jogo usando Textdraws.
+
+Recursos
+- Criação de lojas com múltiplas páginas, descrições e previews
+- Carrinho integrado com limite de slots e exibição do valor total
+- Suporte opcional ao easyDialog quando disponível
+- Strings localizáveis (padrão em inglês; PT-BR e Espanhol incluídos)
+
+Visual
+![MenuStore](https://i.imgur.com/gH1k6t4.jpg)
+
+Links rápidos
+- README em inglês: [README.md](README.md)
+- README em Português (pt-BR): [README.pt-BR.md](README.pt-BR.md)
+- README em Español: [README.es.md](README.es.md)
+- Exemplo de loja: [examples/example.pwn](examples/example.pwn)
+
+Documentação
+https://sampforum.blast.hk/showthread.php?tid=644913
+
+Como começar (resumo)
+1. Coloque o include na pasta `includes` e adicione `#include <MenuStore>` ao seu script.
+2. Adicione itens com `MenuStore_AddItem(...)` antes de mostrar a loja ao jogador.
+3. Mostre a loja usando `MenuStore_Show(playerid, StoreID, "Store Name");`
+
+Exemplo (muito curto)
+1. Adicione itens:
+
+```pawn
+MenuStore_AddItem(playerid, 1, 342, "Granada", 500, "Lance para explodir.", 200);
+```
+
+2. Mostre a loja:
+
+```pawn
+MenuStore_Show(playerid, Weapon_Shop, "Loja de Armas");
+```
+
+3. Implemente o callback da loja (veja [examples/newStore_example.pwn](examples/example.pwn) para um exemplo completo):
+
+```pawn
+Store:Weapon_Shop(playerid, response, itemid, modelid, price, amount, itemname[])
+```
+
+Notas
+- O include fornece textos padrão em Português e Espanhol quando `MENUSTORE_PTBR` ou `MENUSTORE_SPANISH` são definidos antes da inclusão.
+- Mantenha `MS_MAX_ITEMS` e outras macros configuráveis conforme as necessidades do seu projeto.

--- a/examples/example.pwn
+++ b/examples/example.pwn
@@ -1,0 +1,78 @@
+// Example store script for MenuStore (English)
+#include <a_samp>
+#include <MenuStore>
+
+// Optional: define localization (defaults to English)
+// #define MENUSTORE_PTBR
+
+CMD:store(playerid)
+{
+    MenuStore_AddItem(playerid, 1, 342, "Grenade", 500, "Throw to explode.", 200);
+    MenuStore_AddItem(playerid, 2, 344, "Molotov", 500, "Throw to set things on fire.", 200);
+    MenuStore_AddItem(playerid, 3, 346, "9mm Pistol", 500, "Low-power pistol.");
+    MenuStore_AddItem(playerid, 4, 347, "Silenced 9mm", 500, "Low-power pistol with suppressor.");
+    MenuStore_AddItem(playerid, 5, 348, "Desert Eagle", 500, "High-power pistol.");
+    MenuStore_AddItem(playerid, 6, 349, "Shotgun", 500, "Standard shotgun.");
+    MenuStore_AddItem(playerid, 7, 350, "Sawnoff", 500, "Powerful sawed-off shotgun.");
+    MenuStore_AddItem(playerid, 8, 351, "Combat Shotgun", 500, "High-power shotgun.");
+    MenuStore_AddItem(playerid, 9, 352, "Micro SMG", 500, "Submachine gun.");
+    MenuStore_AddItem(playerid, 10, 353, "MP5", 500, "Submachine gun.");
+    MenuStore_AddItem(playerid, 11, 355, "AK-47", 500, "Powerful rifle.");
+    MenuStore_AddItem(playerid, 12, 356, "M4", 500, "Powerful rifle.");
+    MenuStore_AddItem(playerid, 13, 372, "Tec-9", 500, "Powerful SMG.");
+    MenuStore_AddItem(playerid, 14, 357, "Country Rifle", 500, "Standard rifle.");
+    MenuStore_AddItem(playerid, 15, 358, "Sniper Rifle", 500, "High-power sniper rifle.");
+
+    MenuStore_Show(playerid, Weapon_Shop, "Weapon Shop");
+    return 1;
+}
+
+Store:Weapon_Shop(playerid, response, itemid, modelid, price, amount, itemname[])
+{
+    if(!response) return true;
+    if(GetPlayerMoney(playerid) < price) {
+        SendClientMessage(playerid, -1, "You do not have enough money.");
+        return true;
+    }
+
+    GivePlayerWeapon(playerid, GetWeaponIDFromModel(modelid), 200 * amount);
+
+    new string[128];
+    format(string, 128, "You bought %dx %s", amount, itemname);
+    SendClientMessage(playerid, -1, string);
+
+    GivePlayerMoney(playerid, -price);
+    return true;
+}
+
+stock GetWeaponIDFromModel(modelid)
+{
+    new idweapon;
+    switch(modelid)
+    {
+        case 342: idweapon = 16; // Grenade
+        case 344: idweapon = 18; // Molotov
+        case 346: idweapon = 22; // 9mm
+        case 347: idweapon = 23; // Silenced 9mm
+        case 348: idweapon = 24; // Desert Eagle
+        case 349: idweapon = 25; // Shotgun
+        case 350: idweapon = 26; // Sawnoff
+        case 351: idweapon = 27; // Combat Shotgun
+        case 352: idweapon = 28; // Micro SMG
+        case 353: idweapon = 29; // MP5
+        case 355: idweapon = 30; // AK-47
+        case 356: idweapon = 31; // M4
+        case 372: idweapon = 32; // Tec-9
+        case 357: idweapon = 33; // Country Rifle
+        case 358: idweapon = 34; // Sniper Rifle
+        case 359: idweapon = 35; // RPG
+        case 360: idweapon = 36; // HS Rocket
+        case 361: idweapon = 37; // Flamethrower
+        case 362: idweapon = 38; // Minigun
+        case 363: idweapon = 39; // Satchel Charge
+        case 365: idweapon = 41; // Spraycan
+        case 366: idweapon = 42; // Fire Extinguisher
+        case 367: idweapon = 43; // Camera
+    }
+    return idweapon;
+}

--- a/pawn.json
+++ b/pawn.json
@@ -2,6 +2,7 @@
 	"user": "Coystark",
 	"repo": "MenuStore",
 	"contributors":[
-		"STGPrince"
+		"STGPrince",
+		"xBruno1000x"
 	]
 }


### PR DESCRIPTION
What was done:

- Added an option to use native dialogs or easyDialog in MenuStore (auto-detection).
- Refactored cart behavior so each unique item occupies a single cart slot and its quantity is increased/stacked, instead of adding a new slot per click.
- Added translated documentation: README.pt-BR.md and README.es.md, and an English example script at examples/example.pwn.

Context:

After integrating MenuStore into projects with different dialog systems and tighter inventory UX expectations, two issues arose: (1) some integrations prefer using native PAWN dialogs while others rely on easyDialog; (2) clicking to add the same item previously created duplicate cart entries across multiple slots, which wasted limited cart space. This change introduces a simple auto-detection/option to use native dialogs or easyDialog (no extra ID management required) and changes the cart to a single-slot-per-item model that increments item quantity up to the item's stack limit. Additionally, the repository now includes translated READMEs to help integrators adopt the changes.